### PR TITLE
Remove testing on django 1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
 - '3.5'
 - '3.6'
 env:
-- DJANGO="Django>=1.10.0,<1.11.0"
 - DJANGO="Django>=1.11.0,<1.12.0"
 - DJANGO="Django>=2.0,<2.1"
 matrix:


### PR DESCRIPTION
It doesn't look like any of our apps are on 1.10 at the moment, and we don't need to test for this.