### PR TITLE
Include Reply-To header in contact email, if possible

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,8 +1,12 @@
-0.4.1
+0.4.2
+==================
+* Use contact requester's email as Reply-To.
+
+0.4.1 (2018-01-05)
 ==================
 * Retrieve sender from settings
 
-0.4.0
+0.4.0 (2017-12-29)
 ==================
 * Added Django 1.11 support
 * Added Django 2.0 support

--- a/contactus/views.py
+++ b/contactus/views.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from django.conf import settings
-from django.core.mail import send_mail
+from django.core.mail import EmailMessage
 from django.template import loader
 from django.views.generic.edit import FormView
 
@@ -36,7 +36,16 @@ class ContactUsView(FormView):
         sender = settings.SERVER_EMAIL
         recipients = (getattr(settings, 'CONTACT_US_EMAIL'),)
 
+        reply_to = form_data.get('email') or sender
+
         tmpl = loader.get_template(self.email_template_name)
-        send_mail(self.subject, tmpl.render(form_data), sender, recipients)
+        email = EmailMessage(
+            self.subject,
+            tmpl.render(form_data),
+            sender,
+            recipients,
+            reply_to=[reply_to],
+        )
+        email.send()
 
         return super(ContactUsView, self).form_valid(form)


### PR DESCRIPTION
The person requesting the contact request fills out an email in the
contact form. Use this email for the Reply-To header, to make it easier
to reply to them.

https://docs.djangoproject.com/en/2.2/topics/email/#the-emailmessage-class